### PR TITLE
Fix addon preferences register/unregister

### DIFF
--- a/addon_preferences.py
+++ b/addon_preferences.py
@@ -57,4 +57,11 @@ class ArnoldAddonPreferences(AddonPreferences):
 classes = (
     ArnoldAddonPreferences,
 )
-register, unregister = bpy.utils.register_classes_factory(classes)
+
+def register():
+    for c in classes:
+        bpy.utils.register_class(c)
+
+def unregister():
+    for c in reversed(classes):
+        bpy.utils.unregister_class(c)


### PR DESCRIPTION
Replaced `register_classes_factory` with register and unregister functions, which was causing addon register errors.